### PR TITLE
bump to v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.3.1] - 2026-03-06
+
+- Add support for Rails enum columns
+
 ## [0.3.0] - 2025-12-10
 
 - Fix ambiguous column error

--- a/lib/active_record/cursor_paginator/version.rb
+++ b/lib/active_record/cursor_paginator/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   class CursorPaginator
-    VERSION = '0.3.0'
+    VERSION = '0.3.1'
   end
 end


### PR DESCRIPTION
This pull request introduces a new release (version 0.3.1) with added support for Rails enum columns. It also updates the version constant to reflect this change.

- Release notes:
  * Added a changelog entry for version 0.3.1, highlighting support for Rails enum columns.

- Versioning:
  * Updated the `VERSION` constant in `lib/active_record/cursor_paginator/version.rb` from '0.3.0' to '0.3.1'.